### PR TITLE
Improvements for non incremental export

### DIFF
--- a/lib/embulk/input/zendesk/client.rb
+++ b/lib/embulk/input/zendesk/client.rb
@@ -76,6 +76,7 @@ module Embulk
         end
 
         def fetch_subresource(record_id, base, target)
+          Embulk.logger.info "Fetching subresource #{target} of #{base}:#{record_id}"
           response = request("/api/v2/#{base}/#{record_id}/#{target}.json")
           return [] if response.status == 404
 
@@ -91,7 +92,7 @@ module Embulk
 
         def export(path, key, partial, page = 1, known_ids = [], &block)
           per_page = partial ? PARTIAL_RECORDS_SIZE : 100 # 100 is maximum https://developer.zendesk.com/rest_api/docs/core/introduction#pagination
-          Embulk.logger.debug("#{path} with page=#{page}" + (partial ? " (partial)" : ""))
+          Embulk.logger.info("Fetching #{path} with page=#{page}" + (partial ? " (partial)" : ""))
 
           response = request(path, per_page: per_page, page: page)
 
@@ -126,7 +127,7 @@ module Embulk
             rescue => e
               raise Embulk::DataError.new(e)
             end
-            Embulk.logger.debug "start_time:#{start_time} (#{Time.at(start_time)}) count:#{data["count"]} next_page:#{data["next_page"]} end_time:#{data["end_time"]} "
+            Embulk.logger.info "Fetched records from #{start_time} (#{Time.at(start_time)}) to #{data["end_time"]} (#{Time.at(data["end_time"])})"
             records = data[key]
           end
 

--- a/lib/embulk/input/zendesk/plugin.rb
+++ b/lib/embulk/input/zendesk/plugin.rb
@@ -82,7 +82,7 @@ module Embulk
             access_token: config.param("access_token", :string, default: nil),
             start_time: config.param("start_time", :string, default: nil),
             retry_limit: config.param("retry_limit", :integer, default: 5),
-            retry_initial_wait_sec: config.param("retry_initial_wait_sec", :integer, default: 1),
+            retry_initial_wait_sec: config.param("retry_initial_wait_sec", :integer, default: 4),
             incremental: config.param("incremental", :bool, default: true),
             schema: config.param(:columns, :array, default: []),
             includes: config.param(:includes, :array, default: []),

--- a/test/embulk/input/zendesk/test_client.rb
+++ b/test/embulk/input/zendesk/test_client.rb
@@ -97,12 +97,9 @@ module Embulk
             end
 
             test "fetch ticket_metrics all page" do
-              records = [
-                {"id" => 1},
-                {"id" => 2},
-              ]
+              records = 100.times.map{|n| {"id"=> n}}
               second_results = [
-                {"id" => 3}
+                {"id" => 101}
               ]
               @httpclient.test_loopback_http_response << [
                 "HTTP/1.1 200",
@@ -110,6 +107,7 @@ module Embulk
                 "",
                 {
                   ticket_metrics: records,
+                  count: records.length + second_results.length,
                   next_page: "https://treasuredata.zendesk.com/api/v2/ticket_metrics.json?page=2",
                 }.to_json
               ].join("\r\n")
@@ -120,6 +118,7 @@ module Embulk
                 "",
                 {
                   ticket_metrics: second_results,
+                  count: records.length + second_results.length,
                   next_page: nil,
                 }.to_json
               ].join("\r\n")
@@ -146,7 +145,8 @@ module Embulk
                 "Content-Type: application/json",
                 "",
                 {
-                  ticket_metrics: records
+                  ticket_metrics: records,
+                  count: records.length,
                 }.to_json
               ].join("\r\n")
 
@@ -163,7 +163,8 @@ module Embulk
                 "Content-Type: application/json",
                 "",
                 {
-                  ticket_metrics: [{"id" => 1}],
+                  ticket_metrics: 100.times.map{|n| {"id" => n}},
+                  count: 101,
                   next_page: "https://treasuredata.zendesk.com/api/v2/ticket_metrics.json?page=2",
                 }.to_json
               ].join("\r\n")
@@ -173,8 +174,8 @@ module Embulk
                 "Content-Type: application/json",
                 "",
                 {
-                  ticket_metrics: [{"id" => 2}],
-                  count: 2,
+                  ticket_metrics: [{"id" => 101}],
+                  count: 101,
                 }.to_json
               ].join("\r\n")
 
@@ -182,7 +183,7 @@ module Embulk
               @httpclient.test_loopback_http_response << response_2
 
               handler = proc { }
-              mock(handler).call(anything).twice
+              mock(handler).call(anything).times(101)
               client.ticket_metrics(false, &handler)
             end
 
@@ -231,7 +232,7 @@ module Embulk
             end
 
             test "invoke export when partial=false" do
-              mock(client).export(anything, "ticket_fields", anything)
+              mock(client).export_parallel(anything, "ticket_fields")
               client.ticket_fields(false)
             end
           end
@@ -243,7 +244,7 @@ module Embulk
             end
 
             test "invoke export when partial=false" do
-              mock(client).export(anything, "ticket_forms", anything)
+              mock(client).export_parallel(anything, "ticket_forms")
               client.ticket_forms(false)
             end
           end

--- a/test/embulk/input/zendesk/test_client.rb
+++ b/test/embulk/input/zendesk/test_client.rb
@@ -227,7 +227,7 @@ module Embulk
 
           sub_test_case "ticket_fields" do
             test "invoke export when partial=true" do
-              mock(client).export(anything, "ticket_fields", anything)
+              mock(client).export(anything, "ticket_fields")
               client.ticket_fields(true)
             end
 
@@ -239,7 +239,7 @@ module Embulk
 
           sub_test_case "ticket_forms" do
             test "invoke export when partial=true" do
-              mock(client).export(anything, "ticket_forms", anything)
+              mock(client).export(anything, "ticket_forms")
               client.ticket_forms(true)
             end
 

--- a/test/embulk/input/zendesk/test_plugin.rb
+++ b/test/embulk/input/zendesk/test_plugin.rb
@@ -353,6 +353,7 @@ module Embulk
           sub_test_case "run" do
             setup do
               stub(@plugin).preview? { false }
+              stub(Embulk).logger { Logger.new(File::NULL) }
             end
 
             test "call ticket_all method instead of tickets" do
@@ -416,6 +417,7 @@ module Embulk
                 ].join("\r\n")
                 stub(page_builder).add(anything)
                 stub(page_builder).finish
+                stub(Embulk).logger { Logger.new(File::NULL) }
               end
 
               sub_test_case "incremental: true" do
@@ -443,6 +445,7 @@ module Embulk
 
             sub_test_case "casting value" do
               setup do
+                stub(Embulk).logger { Logger.new(File::NULL) }
                 stub(@plugin).preview? { false }
                 @httpclient.test_loopback_http_response << [
                   "HTTP/1.1 200",


### PR DESCRIPTION
- Extend default wait time
- Verbose logging
- Parallelize fetching for non-incremental export (fixed 5 workers for now)
