### PR TITLE
Ignore '422: Too recent start_time'

### DIFF
--- a/test/embulk/input/zendesk/test_client.rb
+++ b/test/embulk/input/zendesk/test_client.rb
@@ -418,6 +418,20 @@ module Embulk
             end
           end
 
+          test "422 with Too recent start_time" do
+            stub_response(422, [], '{"error":"InvalidValue","description":"Too recent start_time. Use a start_time older than 5 minutes"}')
+            assert_nothing_raised do
+              client.tickets(&proc{})
+            end
+          end
+
+          test "422" do
+            stub_response(422)
+            assert_raise(ConfigError) do
+              client.tickets(&proc{})
+            end
+          end
+
           test "429" do
             after = "123"
             stub_response(429, ["Retry-After: #{after}"])


### PR DESCRIPTION
[Zendesk returns "no records" as 422](https://github.com/ppf2/logstash-input-zendesk/blob/ea7819c4c3f3402821ec1483685104f86c300432/lib/logstash/inputs/zendesk.rb#L344-L347)
