### PR TITLE
All *_id columns should be type:long

### DIFF
--- a/lib/embulk/input/zendesk/plugin.rb
+++ b/lib/embulk/input/zendesk/plugin.rb
@@ -57,6 +57,11 @@ module Embulk
             if records.any? {|r| [Array, Hash].include?(r[hash[:name]].class) }
               hash[:type] = :json
             end
+            if hash[:name].match(/_id$/)
+              # NOTE: sometimes *_id will be guessed as timestamp format:%d%m%Y (e.g. 21031998), all *_id columns should be type:long
+              hash[:type] = :long
+              hash.delete(:format) # has it if type:timestamp
+            end
 
             hash
           end

--- a/test/embulk/input/zendesk/test_plugin.rb
+++ b/test/embulk/input/zendesk/test_plugin.rb
@@ -127,6 +127,7 @@ module Embulk
             assert actual.include?(name: "tags", type: :json)
             assert actual.include?(name: "collaborator_ids", type: :json)
             assert actual.include?(name: "custom_fields", type: :json)
+            assert actual.include?(name: "group_id", type: :long)
             assert actual.include?(name: "satisfaction_rating", type: :json)
           end
         end

--- a/test/fixtures/tickets.json
+++ b/test/fixtures/tickets.json
@@ -15,7 +15,7 @@
   "submitter_id":     76872,
   "assignee_id":      235323,
   "organization_id":  509974,
-  "group_id":         98738,
+  "group_id":         21031998,
   "collaborator_ids": [35334, 234],
   "forum_topic_id":   72648221,
   "problem_id":       9873764,


### PR DESCRIPTION
Some id values (e.g. 21031998) will be guessed as `type: timestamp, format: "%d%m%Y"`, but they should be `type: long`.
