### PR TITLE
Fix _id columns to be guessed as string. (e.g. external_id)

### DIFF
--- a/lib/embulk/input/zendesk/plugin.rb
+++ b/lib/embulk/input/zendesk/plugin.rb
@@ -57,9 +57,14 @@ module Embulk
             if records.any? {|r| [Array, Hash].include?(r[hash[:name]].class) }
               hash[:type] = :json
             end
-            if hash[:name].match(/_id$/)
+
+            case hash[:name]
+            when /_id$/
               # NOTE: sometimes *_id will be guessed as timestamp format:%d%m%Y (e.g. 21031998), all *_id columns should be type:string
               hash[:type] = :string
+              hash.delete(:format) # has it if type:timestamp
+            when "id"
+              hash[:type] = :long
               hash.delete(:format) # has it if type:timestamp
             end
 

--- a/lib/embulk/input/zendesk/plugin.rb
+++ b/lib/embulk/input/zendesk/plugin.rb
@@ -58,8 +58,8 @@ module Embulk
               hash[:type] = :json
             end
             if hash[:name].match(/_id$/)
-              # NOTE: sometimes *_id will be guessed as timestamp format:%d%m%Y (e.g. 21031998), all *_id columns should be type:long
-              hash[:type] = :long
+              # NOTE: sometimes *_id will be guessed as timestamp format:%d%m%Y (e.g. 21031998), all *_id columns should be type:string
+              hash[:type] = :string
               hash.delete(:format) # has it if type:timestamp
             end
 

--- a/test/embulk/input/zendesk/test_plugin.rb
+++ b/test/embulk/input/zendesk/test_plugin.rb
@@ -127,7 +127,7 @@ module Embulk
             assert actual.include?(name: "tags", type: :json)
             assert actual.include?(name: "collaborator_ids", type: :json)
             assert actual.include?(name: "custom_fields", type: :json)
-            assert actual.include?(name: "group_id", type: :long)
+            assert actual.include?(name: "group_id", type: :string)
             assert actual.include?(name: "satisfaction_rating", type: :json)
           end
         end


### PR DESCRIPTION
Follow up #15 
I realized that external_id is not a type: long (such as "55a449b32f6e794b1e000003") for target:tickets.
I've changed to all *_id columns to be type:string.
