### PR TITLE
Attempt to resolve ConnectTimeoutError

### DIFF
--- a/lib/embulk/input/zendesk/client.rb
+++ b/lib/embulk/input/zendesk/client.rb
@@ -20,10 +20,16 @@ module Embulk
         end
 
         def httpclient
-          httpclient = HTTPClient.new
-          httpclient.connect_timeout = 240 # default:60 is not enough for huge data
-          # httpclient.debug_dev = STDOUT
-          set_auth(httpclient)
+          # multi-threading + retry can create lot of instances, and each will keep connecting
+          # re-using instance in multi threads can help to omit cleanup code
+          @httpclient ||=
+            begin
+              clnt = HTTPClient.new
+              clnt.connect_timeout = 240 # default:60 is not enough for huge data
+              clnt.receive_timeout = 240 # better change default receive_timeout too
+              # httpclient.debug_dev = STDOUT
+              set_auth(clnt)
+            end
         end
 
         def pool

--- a/test/embulk/input/zendesk/test_client.rb
+++ b/test/embulk/input/zendesk/test_client.rb
@@ -609,6 +609,13 @@ module Embulk
           end
         end
 
+        sub_test_case "should not create new instance of httpclient" do
+          test "not create new instance when re-call" do
+            client = Client.new(login_url: login_url, auth_method: "token", username: username, token: token)
+            assert client.httpclient == client.httpclient
+          end
+        end
+
         def login_url
           "http://example.com"
         end


### PR DESCRIPTION
### BACKGROUND
- Every call to `request` method will create a new instance of `httpclient` instance, without closing/destroying.
### CHANGELOG
- Re-use instance of `httpclient`, in attempt to resolve `ConnectTimeoutError` when there are a lot of `request` invokes.