### PR TITLE
Add flushing to `page_builder`

### DIFF
--- a/lib/embulk/input/zendesk/client.rb
+++ b/lib/embulk/input/zendesk/client.rb
@@ -147,11 +147,9 @@ module Embulk
           # > The ticket metrics api would be possibly better used by supplying a ticket ID to get the metrics of the particular ticket you wish to get get metrics on.
           if key == 'ticket_metrics'
             incremental_export('/api/v2/incremental/tickets.json', 'tickets', start_time, known_ticket_ids, false) do |ticket|
-              pool.process do
-                response = request("/api/v2/tickets/#{ticket['id']}/metrics.json")
-                metrics = JSON.parse(response.body)
-                block.call metrics['ticket_metric'] if metrics['ticket_metric']
-              end
+              response = request("/api/v2/tickets/#{ticket['id']}/metrics.json")
+              metrics = JSON.parse(response.body)
+              block.call metrics['ticket_metric'] if metrics['ticket_metric']
             end
           end
           pool.shutdown

--- a/lib/embulk/input/zendesk/client.rb
+++ b/lib/embulk/input/zendesk/client.rb
@@ -211,7 +211,10 @@ module Embulk
               next if known_ids.include?(record["id"])
 
               known_ids << record["id"]
-              pool.process { yield(record) }
+              pool.process {
+                rename_jruby_thread(Thread.current)
+                yield(record)
+              }
               actual_fetched += 1
             end
             Embulk.logger.info "Fetched #{actual_fetched} records from start_time:#{start_time} (#{Time.at(start_time)}) within #{Time.now.to_i - start_fetching.to_i} seconds"

--- a/lib/embulk/input/zendesk/plugin.rb
+++ b/lib/embulk/input/zendesk/plugin.rb
@@ -121,7 +121,7 @@ module Embulk
             mutex.synchronize do
               page_builder.add(values)
               buf_size += 1
-              if buf_size > BUFFER_SIZE
+              if buf_size >= BUFFER_SIZE
                 page_builder.flush
                 buf_size = 0
                 Embulk.logger.info "Flushed #{BUFFER_SIZE} records of #{task[:target]}"

--- a/lib/embulk/input/zendesk/plugin.rb
+++ b/lib/embulk/input/zendesk/plugin.rb
@@ -6,7 +6,7 @@ module Embulk
     module Zendesk
       class Plugin < InputPlugin
         ::Embulk::Plugin.register_input("zendesk", self)
-        BUFFER_SIZE = 10000 # flush each 1k records
+        BUFFER_LENGTH = 10000 # flush each 10k records
 
         def self.transaction(config, &control)
           task = config_to_task(config)
@@ -121,10 +121,10 @@ module Embulk
             mutex.synchronize do
               page_builder.add(values)
               buf_size += 1
-              if buf_size >= BUFFER_SIZE
+              if buf_size >= BUFFER_LENGTH
                 page_builder.flush
                 buf_size = 0
-                Embulk.logger.info "Flushed #{BUFFER_SIZE} records of #{task[:target]}"
+                Embulk.logger.info "Flushed #{BUFFER_LENGTH} records of #{task[:target]}"
               end
             end
             break if preview? # NOTE: preview take care only 1 record. subresources fetching is slow.


### PR DESCRIPTION
* Add flushing to `page_builder`, flush per 10k records
* Remove redundant forked thread when pulling individual `ticket_metrics`, it's already in separated thread
