### PR TITLE
Fix thread pool bottleneck

### DIFF
--- a/lib/embulk/input/zendesk/plugin.rb
+++ b/lib/embulk/input/zendesk/plugin.rb
@@ -166,7 +166,15 @@ module Embulk
         end
 
         def pool
-          @pool ||= Thread.pool([Client::THREADPOOL_SIZE, (task[:includes] || []).length].max)
+          includes_length = (task[:includes] || []).length
+          @pool ||=
+            begin
+              if includes_length < Client::THREADPOOL_MIN_SIZE
+                Thread.pool(includes_length)
+              else
+                Thread.pool(Client::THREADPOOL_MIN_SIZE, Client::THREADPOOL_MAX_SIZE)
+              end
+            end
         end
 
         def preview?

--- a/lib/embulk/input/zendesk/plugin.rb
+++ b/lib/embulk/input/zendesk/plugin.rb
@@ -1,6 +1,8 @@
 require 'perfect_retry'
 require 'thread/pool'
 
+Thread::Pool.abort_on_exception = true
+
 module Embulk
   module Input
     module Zendesk


### PR DESCRIPTION
### What happens?
* When plugin needs to pull a lot of individual record, for ex: `ticket_metrics`, and especially when there is high latency on API, thread pool tasks will get bottlenecked due to low pool size.

### How this PR helps?
* Base on my tests, 50-100 seems to be a good choice, not too much to cause out of memory error, not too low to cause bottleneck. Of course it needs to be revised in future.

### What to do next?
There is some possibilities for improvement:
* Replace `thread` gem with more robust implementation, such as: [`concurrent-ruby`](https://github.com/ruby-concurrency/concurrent-ruby)
* Wait for availability of free slots in thread pool
* Improve JVM if JRuby is used, especially GC flags