### PR TITLE
Replace `thread` gem with `concurrent-ruby`, for robustness

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org/'
+gem 'concurrent-ruby', require: 'concurrent'
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,2 @@
 source 'https://rubygems.org/'
-gem 'concurrent-ruby', require: 'concurrent'
 gemspec

--- a/embulk-input-zendesk.gemspec
+++ b/embulk-input-zendesk.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'perfect_retry', '~> 0.5'
   spec.add_dependency 'httpclient'
+  spec.add_dependency 'concurrent-ruby'
   spec.add_development_dependency 'embulk', ['~> 0.8.1']
   spec.add_development_dependency 'bundler', ['~> 1.0']
   spec.add_development_dependency 'rake', ['>= 10.0']

--- a/embulk-input-zendesk.gemspec
+++ b/embulk-input-zendesk.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'perfect_retry', '~> 0.5'
   spec.add_dependency 'httpclient'
-  spec.add_dependency 'thread'
   spec.add_development_dependency 'embulk', ['~> 0.8.1']
   spec.add_development_dependency 'bundler', ['~> 1.0']
   spec.add_development_dependency 'rake', ['>= 10.0']

--- a/test/embulk/input/zendesk/test_plugin.rb
+++ b/test/embulk/input/zendesk/test_plugin.rb
@@ -577,6 +577,7 @@ module Embulk
             end
 
             test "flush is called twice" do
+              omit("This test is no longer valid, flushing is removed now")
               mock(page_builder).add(anything).times(20001)
               mock(page_builder).flush.times(2)
               mock(page_builder).finish


### PR DESCRIPTION
This PR is 2nd attempt to improve performance when pulling a large list of `ticket_metrics`.

### CHANGELOG
- Replace `thread` gem with `concurrent-ruby`, for robustness
- Remove `page_builder.flush()` and thread pool usage when pulling `includes` entities since they're not useful