### PR TITLE
Release v0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.7 - 2017-07-19
+* [fixed] Ensure thread pool is shutdown [#38](https://github.com/treasure-data/embulk-input-zendesk/pull/38)
+* [enhancement] Add retry for temporary error: missing required key from JSON response
+
 ## 0.2.6 - 2017-05-23
 * [enhancement] Enable incremental loading for ticket_metrics
 

--- a/embulk-input-zendesk.gemspec
+++ b/embulk-input-zendesk.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "embulk-input-zendesk"
-  spec.version       = "0.2.6"
+  spec.version       = "0.2.7"
   spec.authors       = ["uu59", "muga", "sakama"]
   spec.summary       = "Zendesk input plugin for Embulk"
   spec.description   = "Loads records from Zendesk."


### PR DESCRIPTION
* [fixed] Ensure thread pool is shutdown [#38](https://github.com/treasure-data/embulk-input-zendesk/pull/38)
* [enhancement] Add retry for temporary error: missing required key from JSON response