### PR TITLE
Release v0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.9 - 2017-08-03
+* [fixed] `start_time` is not merged to `query`, causing infinite loop [#42](https://github.com/treasure-data/embulk-input-zendesk/pull/42)
+
 ## 0.2.8 - 2017-07-28
 * [fixed] Raise `DataError` instead of `TempError` after giving up for `TempError` [#40](https://github.com/treasure-data/embulk-input-zendesk/pull/40)
 * [enhancement] Only rescue `TempError` when executing thread pool, only create/shutdown pool once during retry, move retry to inside of `execute_thread_pool`

--- a/embulk-input-zendesk.gemspec
+++ b/embulk-input-zendesk.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "embulk-input-zendesk"
-  spec.version       = "0.2.8"
+  spec.version       = "0.2.9"
   spec.authors       = ["uu59", "muga", "sakama"]
   spec.summary       = "Zendesk input plugin for Embulk"
   spec.description   = "Loads records from Zendesk."


### PR DESCRIPTION
* [fixed] `start_time` is not merged to `query`, causing infinite loop [#42](https://github.com/treasure-data/embulk-input-zendesk/pull/42)
