### PR TITLE
Add 3 properties to include app marketplace API headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ Required Embulk version >= 0.8.1.
 - **retry_limit**: Try to retry this times (integer, default: 5)
 - **retry_initial_wait_sec**: Wait seconds for exponential backoff initial value (integer, default: 4)
 - **incremental**:  If false, `start_time` in next.yml would not be updated that means you always fetch all of data from Zendesk with statically conditions. If true, `start_time` would be updated in next.yml. (bool, default: true)
-
+- **app_marketplace_integration_name**: Invisible to user, only requires to be a part of the Zendesk Apps Marketplace. This should be used to name of the integration.
+- **app_marketplace_org_id**: Invisible to user, only requires to be a part of the Zendesk Apps Marketplace. This should be the Organization ID for your organization from the new developer portal.
+- **app_marketplace_app_id**: Invisible to user, only requires to be a part of the Zendesk Apps Marketplace. This is the “App ID” that will be assigned to you when you submit your app.
+  
 ## Example
 
 ```yaml

--- a/lib/embulk/input/zendesk/client.rb
+++ b/lib/embulk/input/zendesk/client.rb
@@ -43,6 +43,7 @@ module Embulk
         def validate_config
           validate_credentials
           validate_target
+          validate_app_marketplace
         end
 
         def validate_credentials
@@ -65,6 +66,15 @@ module Embulk
         def validate_target
           unless AVAILABLE_TARGETS.include?(config[:target])
             raise Embulk::ConfigError.new("target: '#{config[:target]}' is not supported. Supported targets are #{AVAILABLE_TARGETS.join(", ")}.")
+          end
+        end
+
+        def validate_app_marketplace
+          valid = config[:app_marketplace_integration_name] && config[:app_marketplace_org_id] && config[:app_marketplace_app_id]
+          valid = valid || (!config[:app_marketplace_integration_name] && !config[:app_marketplace_org_id] && !config[:app_marketplace_app_id])
+
+          unless valid
+             raise Embulk::ConfigError.new("All of app_marketplace_integration_name, app_marketplace_org_id, app_marketplace_app_id are required to fill out for Apps Marketplace API header")
           end
         end
 

--- a/lib/embulk/input/zendesk/client.rb
+++ b/lib/embulk/input/zendesk/client.rb
@@ -266,7 +266,7 @@ module Embulk
 
           retryer.with_retry do
             Embulk.logger.debug "Fetching #{u.to_s}"
-            response = httpclient.get(u.to_s, query, extheader, false)
+            response = httpclient.get(u.to_s, query, extheader)
 
             handle_response(response.status, response.headers, response.body)
             response
@@ -293,7 +293,7 @@ module Embulk
             Embulk.logger.debug "Fetching #{u.to_s}"
             buf = ""
             auth_retry = 0
-            httpclient.get(u.to_s, query, extheader, false) do |message, chunk|
+            httpclient.get(u.to_s, query, extheader) do |message, chunk|
               if message.status == 401
                 # First request will fail by 401 because not included credentials.
                 # HTTPClient will retry request with credentials.

--- a/lib/embulk/input/zendesk/client.rb
+++ b/lib/embulk/input/zendesk/client.rb
@@ -259,14 +259,14 @@ module Embulk
           extheader = {}
 
           if config[:app_marketplace_integration_name] && config[:app_marketplace_org_id] && config[:app_marketplace_app_id]
-            extheader = {'X-Zendesk-Marketplace-Name' => config[:app_marketplace_integration_name],
-                         'X-Zendesk-Marketplace-Organization-Id' => config[:app_marketplace_org_id],
-                         'X-Zendesk-Marketplace-App-Id' => config[:app_marketplace_app_id]}
+            extheader = {"X-Zendesk-Marketplace-Name" => config[:app_marketplace_integration_name],
+                         "X-Zendesk-Marketplace-Organization-Id" => config[:app_marketplace_org_id],
+                         "X-Zendesk-Marketplace-App-Id" => config[:app_marketplace_app_id]}
           end
 
           retryer.with_retry do
             Embulk.logger.debug "Fetching #{u.to_s}"
-            response = httpclient.get(u.to_s, query, extheader, follow_redirect: true)
+            response = httpclient.get(u.to_s, query, extheader, false)
 
             handle_response(response.status, response.headers, response.body)
             response
@@ -284,16 +284,16 @@ module Embulk
           extheader = {}
 
           if config[:app_marketplace_integration_name] && config[:app_marketplace_org_id] && config[:app_marketplace_app_id]
-            extheader = {'X-Zendesk-Marketplace-Name' => config[:app_marketplace_integration_name],
-                         'X-Zendesk-Marketplace-Organization-Id' => config[:app_marketplace_org_id],
-                         'X-Zendesk-Marketplace-App-Id' => config[:app_marketplace_app_id]}
+            extheader = {"X-Zendesk-Marketplace-Name" => config[:app_marketplace_integration_name],
+                         "X-Zendesk-Marketplace-Organization-Id" => config[:app_marketplace_org_id],
+                         "X-Zendesk-Marketplace-App-Id" => config[:app_marketplace_app_id]}
           end
 
           retryer.with_retry do
             Embulk.logger.debug "Fetching #{u.to_s}"
             buf = ""
             auth_retry = 0
-            httpclient.get(u.to_s, query, extheader, follow_redirect: true) do |message, chunk|
+            httpclient.get(u.to_s, query, extheader, false) do |message, chunk|
               if message.status == 401
                 # First request will fail by 401 because not included credentials.
                 # HTTPClient will retry request with credentials.

--- a/lib/embulk/input/zendesk/client.rb
+++ b/lib/embulk/input/zendesk/client.rb
@@ -255,9 +255,18 @@ module Embulk
           u = URI.parse(config[:login_url])
           u.path = path
 
+          # https://help.zendesk.com/hc/en-us/articles/115010249348-Announcing-Updated-Apps-Marketplace-API-Header-Requirementsmerg
+          extheader = {}
+
+          if config[:app_marketplace_integration_name] && config[:app_marketplace_org_id] && config[:app_marketplace_app_id]
+            extheader = {'X-Zendesk-Marketplace-Name' => config[:app_marketplace_integration_name],
+                         'X-Zendesk-Marketplace-Organization-Id' => config[:app_marketplace_org_id],
+                         'X-Zendesk-Marketplace-App-Id' => config[:app_marketplace_app_id]}
+          end
+
           retryer.with_retry do
             Embulk.logger.debug "Fetching #{u.to_s}"
-            response = httpclient.get(u.to_s, query, follow_redirect: true)
+            response = httpclient.get(u.to_s, query, extheader, follow_redirect: true)
 
             handle_response(response.status, response.headers, response.body)
             response
@@ -271,11 +280,20 @@ module Embulk
           u = URI.parse(config[:login_url])
           u.path = path
 
+          # https://help.zendesk.com/hc/en-us/articles/115010249348-Announcing-Updated-Apps-Marketplace-API-Header-Requirementsmerg
+          extheader = {}
+
+          if config[:app_marketplace_integration_name] && config[:app_marketplace_org_id] && config[:app_marketplace_app_id]
+            extheader = {'X-Zendesk-Marketplace-Name' => config[:app_marketplace_integration_name],
+                         'X-Zendesk-Marketplace-Organization-Id' => config[:app_marketplace_org_id],
+                         'X-Zendesk-Marketplace-App-Id' => config[:app_marketplace_app_id]}
+          end
+
           retryer.with_retry do
             Embulk.logger.debug "Fetching #{u.to_s}"
             buf = ""
             auth_retry = 0
-            httpclient.get(u.to_s, query, follow_redirect: true) do |message, chunk|
+            httpclient.get(u.to_s, query, extheader, follow_redirect: true) do |message, chunk|
               if message.status == 401
                 # First request will fail by 401 because not included credentials.
                 # HTTPClient will retry request with credentials.

--- a/lib/embulk/input/zendesk/plugin.rb
+++ b/lib/embulk/input/zendesk/plugin.rb
@@ -96,6 +96,9 @@ module Embulk
             incremental: config.param("incremental", :bool, default: true),
             schema: config.param(:columns, :array, default: []),
             includes: config.param(:includes, :array, default: []),
+            app_marketplace_integration_name: config.param("app_marketplace_integration_name", :string, default: nil),
+            app_marketplace_org_id: config.param("app_marketplace_org_id", :string, default: nil),
+            app_marketplace_app_id: config.param("app_marketplace_app_id", :string, default: nil)
           }
         end
 

--- a/test/embulk/input/zendesk/test_client.rb
+++ b/test/embulk/input/zendesk/test_client.rb
@@ -78,7 +78,7 @@ module Embulk
               assert_include(result_array,record)
               counter.increment
             }
-            proxy(@httpclient).get("#{login_url}/api/v2/incremental/tickets.json", {:include => "metric_sets", :start_time => start_time}, anything)
+            proxy(@httpclient).get("#{login_url}/api/v2/incremental/tickets.json", {:include => "metric_sets", :start_time => start_time}, anything, false)
             client.ticket_metrics(false, start_time, &handler)
             assert_equal(counter.value, result_array.size)
           end
@@ -166,8 +166,8 @@ module Embulk
                   counter.increment
               }
 
-              proxy(@httpclient).get("#{login_url}/api/v2/incremental/tickets.json", {:include => "metric_sets", :start_time => 0}, anything)
-              proxy(@httpclient).get("#{login_url}/api/v2/incremental/tickets.json", {:include => "metric_sets",:start_time => end_time}, anything)
+              proxy(@httpclient).get("#{login_url}/api/v2/incremental/tickets.json", {:include => "metric_sets", :start_time => 0}, anything, false)
+              proxy(@httpclient).get("#{login_url}/api/v2/incremental/tickets.json", {:include => "metric_sets",:start_time => end_time}, anything, false)
 
               client.ticket_metrics(false, &handler)
               assert_equal(counter.value, result_array.size)
@@ -224,8 +224,8 @@ module Embulk
               @httpclient.test_loopback_http_response << response_2
               counter = Concurrent::AtomicFixnum.new(0)
               handler = proc { counter.increment }
-              proxy(@httpclient).get("#{login_url}/api/v2/incremental/tickets.json",{:include=>"metric_sets", :start_time=>0},anything)
-              proxy(@httpclient).get("#{login_url}/api/v2/incremental/tickets.json",{:include=>"metric_sets", :start_time=>end_time},anything)
+              proxy(@httpclient).get("#{login_url}/api/v2/incremental/tickets.json",{:include=>"metric_sets", :start_time=>0},anything, false)
+              proxy(@httpclient).get("#{login_url}/api/v2/incremental/tickets.json",{:include=>"metric_sets", :start_time=>end_time},anything, false)
               client.ticket_metrics(false, &handler)
               assert_equal(101, counter.value)
             end

--- a/test/embulk/input/zendesk/test_client.rb
+++ b/test/embulk/input/zendesk/test_client.rb
@@ -78,7 +78,7 @@ module Embulk
               assert_include(result_array,record)
               counter.increment
             }
-            proxy(@httpclient).get("#{login_url}/api/v2/incremental/tickets.json", {:include => "metric_sets", :start_time => start_time}, anything, false)
+            proxy(@httpclient).get("#{login_url}/api/v2/incremental/tickets.json", {:include => "metric_sets", :start_time => start_time}, anything)
             client.ticket_metrics(false, start_time, &handler)
             assert_equal(counter.value, result_array.size)
           end
@@ -166,8 +166,8 @@ module Embulk
                   counter.increment
               }
 
-              proxy(@httpclient).get("#{login_url}/api/v2/incremental/tickets.json", {:include => "metric_sets", :start_time => 0}, anything, false)
-              proxy(@httpclient).get("#{login_url}/api/v2/incremental/tickets.json", {:include => "metric_sets",:start_time => end_time}, anything, false)
+              proxy(@httpclient).get("#{login_url}/api/v2/incremental/tickets.json", {:include => "metric_sets", :start_time => 0}, anything)
+              proxy(@httpclient).get("#{login_url}/api/v2/incremental/tickets.json", {:include => "metric_sets",:start_time => end_time}, anything)
 
               client.ticket_metrics(false, &handler)
               assert_equal(counter.value, result_array.size)
@@ -224,8 +224,8 @@ module Embulk
               @httpclient.test_loopback_http_response << response_2
               counter = Concurrent::AtomicFixnum.new(0)
               handler = proc { counter.increment }
-              proxy(@httpclient).get("#{login_url}/api/v2/incremental/tickets.json",{:include=>"metric_sets", :start_time=>0},anything, false)
-              proxy(@httpclient).get("#{login_url}/api/v2/incremental/tickets.json",{:include=>"metric_sets", :start_time=>end_time},anything, false)
+              proxy(@httpclient).get("#{login_url}/api/v2/incremental/tickets.json",{:include=>"metric_sets", :start_time=>0},anything)
+              proxy(@httpclient).get("#{login_url}/api/v2/incremental/tickets.json",{:include=>"metric_sets", :start_time=>end_time},anything)
               client.ticket_metrics(false, &handler)
               assert_equal(101, counter.value)
             end

--- a/test/embulk/input/zendesk/test_plugin.rb
+++ b/test/embulk/input/zendesk/test_plugin.rb
@@ -50,6 +50,26 @@ module Embulk
               run_with("invalid_lack_username.yml")
             end
           end
+
+          test "run with valid.yml (app_marketplace) contains three properties" do
+            assert_nothing_raised do
+              run_with("valid_app_marketplace.yml")
+            end
+          end
+
+          test "run with invalid lack one of app marketplace properties" do
+            # NOTE: will be raised Java::OrgEmbulkExec::PartialExecutionException, not ConfigError. It is Embulk internally exception handling matter.
+            assert_raise do
+              run_with("invalid_app_marketplace_lack_one_property.yml")
+            end
+          end
+
+          test "run with invalid lack two of app marketplace properties" do
+            # NOTE: will be raised Java::OrgEmbulkExec::PartialExecutionException, not ConfigError. It is Embulk internally exception handling matter.
+            assert_raise do
+              run_with("invalid_app_marketplace_lack_two_property.yml")
+            end
+          end
         end
 
         sub_test_case ".transaction" do

--- a/test/fixtures/invalid_app_marketplace_lack_one_property.yml
+++ b/test/fixtures/invalid_app_marketplace_lack_one_property.yml
@@ -1,0 +1,13 @@
+in:
+  type: zendesk
+  login_url: "https://example.zendesk.com/"
+  auth_method: basic
+  target: tickets
+  username: foo@example.com
+  password: password
+  app_marketplace_integration_name: App Name for Zendesk
+  app_marketplace_org_id: 12345
+  columns:
+    - {name: id, type: string}
+out:
+  type: "null"

--- a/test/fixtures/invalid_app_marketplace_lack_two_property.yml
+++ b/test/fixtures/invalid_app_marketplace_lack_two_property.yml
@@ -1,0 +1,12 @@
+in:
+  type: zendesk
+  login_url: "https://example.zendesk.com/"
+  auth_method: basic
+  target: tickets
+  username: foo@example.com
+  password: password
+  app_marketplace_integration_name: App Name for Zendesk
+  columns:
+    - {name: id, type: string}
+out:
+  type: "null"

--- a/test/fixtures/valid_app_marketplace.yml
+++ b/test/fixtures/valid_app_marketplace.yml
@@ -1,0 +1,14 @@
+in:
+  type: zendesk
+  login_url: "https://example.zendesk.com/"
+  auth_method: basic
+  target: tickets
+  username: foo@example.com
+  password: password
+  app_marketplace_integration_name: App Name for Zendesk
+  app_marketplace_org_id: 12345
+  app_marketplace_app_id: 99999
+  columns:
+    - {name: id, type: string}
+out:
+  type: "null"


### PR DESCRIPTION
Follow up https://help.zendesk.com/hc/en-us/articles/115010249348-Announcing-Updated-Apps-Marketplace-API-Header-Requirements.

All partners that wish to be a part of the Zendesk Apps Marketplace will be required to include the following custom headers for any requests to the Zendesk API from an external source:

X-Zendesk-Marketplace-Name:"App Name for Zendesk"
X-Zendesk-Marketplace-Organization-Id:12345
X-Zendesk-Marketplace-App-Id: 99999