### PR TITLE
Fix performance issue

### DIFF
--- a/test/embulk/input/zendesk/test_client.rb
+++ b/test/embulk/input/zendesk/test_client.rb
@@ -1,6 +1,7 @@
 require "embulk"
 Embulk.setup
 
+require "set"
 require "yaml"
 require "embulk/input/zendesk"
 require "override_assert_raise"
@@ -258,12 +259,12 @@ module Embulk
 
           sub_test_case "ticket_events" do
             test "invoke incremental_export when partial=true" do
-              mock(client).incremental_export(anything, "ticket_events", anything, [], true)
+              mock(client).incremental_export(anything, "ticket_events", anything, Set.new, true)
               client.ticket_events(true)
             end
 
             test "invoke incremental_export when partial=false" do
-              mock(client).incremental_export(anything, "ticket_events", anything, [], false)
+              mock(client).incremental_export(anything, "ticket_events", anything, Set.new, false)
               client.ticket_events(false)
             end
           end

--- a/test/embulk/input/zendesk/test_plugin.rb
+++ b/test/embulk/input/zendesk/test_plugin.rb
@@ -379,7 +379,7 @@ module Embulk
 
             test "call ticket_all method instead of tickets" do
               mock(@client).export.never
-              mock(@client).incremental_export(anything, "tickets", 0, [], false) { [] }
+              mock(@client).incremental_export(anything, "tickets", 0, Set.new, false) { [] }
               mock(page_builder).finish
 
               @plugin.run


### PR DESCRIPTION
### Background
Current de-dup logic is using an array of `known_ids`. And when the array reaches millions of elements, searching will get slower.

This PR changes `known_ids` to `Set`, to improve searching performance.