### PR TITLE
Add new option: `dedup`, default to `true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Required Embulk version >= 0.8.1.
 - **start_time**: Start export from this time if present. (string, default: `null`)
 - **retry_limit**: Try to retry this times (integer, default: 5)
 - **retry_initial_wait_sec**: Wait seconds for exponential backoff initial value (integer, default: 4)
-- **incremental**:  If false, `start_time` in next.yml would not be updated that means you always fetch all of data from Zendesk with statically conditions. If true, `start_time` would be updated in next.yml. (bool, default: true)
+- **incremental**: If false, `start_time` in next.yml would not be updated that means you always fetch all of data from Zendesk with statically conditions. If true, `start_time` would be updated in next.yml. (bool, default: `true`)
+- **dedup**: Zendesk incremental API is not designed to protect against duplication. In order to de-dup records, plugin has to cache fetched IDs in memory. If you're importing a large dataset (eg. tens of millions of records), it can lead to OOM error, depends on your configured heap size. In such cases, you can set this option to `false`, but keep in mind that result may contain duplicated records. (bool, default: `true`)
 - **app_marketplace_integration_name**: Invisible to user, only requires to be a part of the Zendesk Apps Marketplace. This should be used to name of the integration.
 - **app_marketplace_org_id**: Invisible to user, only requires to be a part of the Zendesk Apps Marketplace. This should be the Organization ID for your organization from the new developer portal.
 - **app_marketplace_app_id**: Invisible to user, only requires to be a part of the Zendesk Apps Marketplace. This is the “App ID” that will be assigned to you when you submit your app.

--- a/lib/embulk/input/zendesk/client.rb
+++ b/lib/embulk/input/zendesk/client.rb
@@ -185,7 +185,7 @@ module Embulk
           end
 
           if !dedup
-            Embulk.logger.warn("!!!You've chosen to disable de-duplicate records, result may contain duplicated data!!!")
+            Embulk.logger.warn("!!! You've selected to skip de-duplicating records, result may contain duplicated data !!!")
           end
 
           execute_thread_pool do |pool|

--- a/lib/embulk/input/zendesk/client.rb
+++ b/lib/embulk/input/zendesk/client.rb
@@ -82,23 +82,23 @@ module Embulk
         # they have both Incremental API and non-incremental API
         # 170717: `ticket_events` can use standard endpoint format now, ie. `<target>.json`
         %w(tickets ticket_events users organizations).each do |target|
-          define_method(target) do |partial = true, start_time = 0, &block|
+          define_method(target) do |partial = true, start_time = 0, dedup = true, &block|
             # Always use incremental_export. There is some difference between incremental_export and export.
-            incremental_export("/api/v2/incremental/#{target}.json", target, start_time, Set.new, partial, &block)
+            incremental_export("/api/v2/incremental/#{target}.json", target, start_time, dedup, Set.new, partial, &block)
           end
         end
 
         # Ticket metrics will need to be export using both the non incremental and incremental on ticket
         # We provide support by filter out ticket_metrics with created at smaller than start time
         # while passing the incremental start time to the incremental ticket/ticket_metrics export
-        define_method('ticket_metrics') do |partial = true, start_time = 0, &block|
+        define_method('ticket_metrics') do |partial = true, start_time = 0, dedup = true, &block|
           if partial
             # If partial export then we need to use the old end point. Since new end point return both ticket and
             # ticket metric with ticket come first so the current approach that cut off the response packet won't work
             # Since partial is only use for preview and guess so this should be fine
             export('/api/v2/ticket_metrics.json', 'ticket_metrics', &block)
           else
-            incremental_export('/api/v2/incremental/tickets.json', 'metric_sets', start_time, Set.new, partial, { include: 'metric_sets' }, &block)
+            incremental_export('/api/v2/incremental/tickets.json', 'metric_sets', start_time, dedup, Set.new, partial, { include: 'metric_sets' }, &block)
           end
         end
 
@@ -175,13 +175,17 @@ module Embulk
           end
         end
 
-        def incremental_export(path, key, start_time = 0, known_ids = Set.new, partial = true, query = {}, &block)
+        def incremental_export(path, key, start_time = 0, dedup = true, known_ids = Set.new, partial = true, query = {}, &block)
           if partial
             records = request_partial(path, query.merge(start_time: start_time)).first(5)
             records.uniq{|r| r["id"]}.each do |record|
               block.call record
             end
             return
+          end
+
+          if !dedup
+            Embulk.logger.warn("!!!You've chosen to disable de-duplicate records, result may contain duplicated data!!!")
           end
 
           execute_thread_pool do |pool|
@@ -208,9 +212,11 @@ module Embulk
                 # de-duplicated records.
                 # https://developer.zendesk.com/rest_api/docs/core/incremental_export#usage-notes
                 # https://github.com/zendesk/zendesk_api_client_rb/issues/251
-                next if known_ids.include?(record["id"])
+                if dedup
+                  next if known_ids.include?(record["id"])
+                  known_ids << record["id"]
+                end
 
-                known_ids << record["id"]
                 pool.post { block.call record }
                 actual_fetched += 1
               end

--- a/lib/embulk/input/zendesk/plugin.rb
+++ b/lib/embulk/input/zendesk/plugin.rb
@@ -94,6 +94,7 @@ module Embulk
             retry_limit: config.param("retry_limit", :integer, default: 5),
             retry_initial_wait_sec: config.param("retry_initial_wait_sec", :integer, default: 4),
             incremental: config.param("incremental", :bool, default: true),
+            dedup: config.param("dedup", :bool, default: true),
             schema: config.param(:columns, :array, default: []),
             includes: config.param(:includes, :array, default: []),
             app_marketplace_integration_name: config.param("app_marketplace_integration_name", :string, default: nil),
@@ -111,6 +112,11 @@ module Embulk
           args = [preview?]
           if @start_time
             args << @start_time.to_i
+          end
+
+          # de-dup may lead to OOM
+          if !task[:dedup].nil? && !task[:dedup]
+            args << false
           end
 
           mutex = Mutex.new

--- a/lib/embulk/input/zendesk/plugin.rb
+++ b/lib/embulk/input/zendesk/plugin.rb
@@ -110,13 +110,11 @@ module Embulk
         def run
           method = task[:target]
           args = [preview?]
-          if @start_time
-            args << @start_time.to_i
-          end
+          args << (@start_time || 0).to_i
 
           # de-dup may lead to OOM
           if !task[:dedup].nil? && !task[:dedup]
-            args += [@start_time || 0, false]
+            args << false
           end
 
           mutex = Mutex.new

--- a/lib/embulk/input/zendesk/plugin.rb
+++ b/lib/embulk/input/zendesk/plugin.rb
@@ -116,7 +116,7 @@ module Embulk
 
           # de-dup may lead to OOM
           if !task[:dedup].nil? && !task[:dedup]
-            args << false
+            args += [@start_time || 0, false]
           end
 
           mutex = Mutex.new

--- a/test/embulk/input/zendesk/test_plugin.rb
+++ b/test/embulk/input/zendesk/test_plugin.rb
@@ -340,7 +340,7 @@ module Embulk
 
             test "call tickets method instead of ticket_all" do
               mock(@client).export.never
-              mock(@client).incremental_export(anything, "tickets", anything, anything, anything) { [] }
+              mock(@client).incremental_export(anything, "tickets", anything, anything, anything, anything) { [] }
               mock(page_builder).finish
 
               @plugin.run
@@ -379,7 +379,7 @@ module Embulk
 
             test "call ticket_all method instead of tickets" do
               mock(@client).export.never
-              mock(@client).incremental_export(anything, "tickets", 0, Set.new, false) { [] }
+              mock(@client).incremental_export(anything, "tickets", 0, true, Set.new, false) { [] }
               mock(page_builder).finish
 
               @plugin.run

--- a/test/embulk/input/zendesk/test_plugin.rb
+++ b/test/embulk/input/zendesk/test_plugin.rb
@@ -544,7 +544,7 @@ module Embulk
               test "Nothing passed to client" do
                 stub(page_builder).finish
 
-                mock(@client).tickets(false)
+                mock(@client).tickets(false, 0)
                 @plugin.run
               end
             end


### PR DESCRIPTION
#### Context
- Follow up #47 
- In attempt to avoid OOM as `known_ids` keeps growing, this PR introduces a new config to disable de-dup logic.