### PR TITLE
Support end_time field for incremental

### DIFF
--- a/src/main/java/org/embulk/input/zendesk/ZendeskInputPlugin.java
+++ b/src/main/java/org/embulk/input/zendesk/ZendeskInputPlugin.java
@@ -234,6 +234,14 @@ public class ZendeskInputPlugin implements InputPlugin
                 configDiff.set(ZendeskConstants.Field.START_TIME,
                         offsetDateTime.format(DateTimeFormatter.ofPattern(ZendeskConstants.Misc.RUBY_TIMESTAMP_FORMAT_INPUT)));
             }
+
+            if (taskReport.has(ZendeskConstants.Field.END_TIME)) {
+                final OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(Instant.ofEpochSecond(
+                        taskReport.get(JsonNode.class, ZendeskConstants.Field.END_TIME).asLong()), ZoneOffset.UTC);
+
+                configDiff.set(ZendeskConstants.Field.END_TIME,
+                        offsetDateTime.format(DateTimeFormatter.ofPattern(ZendeskConstants.Misc.RUBY_TIMESTAMP_FORMAT_INPUT)));
+            }
         }
         return configDiff;
     }
@@ -364,6 +372,7 @@ public class ZendeskInputPlugin implements InputPlugin
         validateIncremental(task);
         validateCustomObject(task);
         validateUserEvent(task);
+        validateTime(task);
     }
 
     private void validateCredentials(PluginTask task)
@@ -439,7 +448,11 @@ public class ZendeskInputPlugin implements InputPlugin
             if (!task.getProfileSource().isPresent()) {
                 throw new ConfigException("Profile Source is required for User Event Target");
             }
-
+        }
+    }
+    private void validateTime(PluginTask task)
+    {
+        if (getZendeskService(task).isSupportIncremental()) {
             // Can't set end_time to 0, so it should be valid
             task.getEndTime().ifPresent(time -> {
                 if (!ZendeskDateUtils.supportedTimeFormat(task.getEndTime().get()).isPresent()) {

--- a/src/main/java/org/embulk/input/zendesk/ZendeskInputPlugin.java
+++ b/src/main/java/org/embulk/input/zendesk/ZendeskInputPlugin.java
@@ -206,7 +206,7 @@ public class ZendeskInputPlugin implements InputPlugin
                 throw new ConfigException("Invalid End time. End time is greater than current time");
             }
             else {
-                logger.info("The end time, '" + task.getEndTime().get() + "', is greater than the current time. No records will be imported");
+                logger.warn("The end time, '" + task.getEndTime().get() + "', is greater than the current time. No records will be imported");
 
                 // we just need to store config_diff when incremental_mode is enable
                 if (task.getIncremental()) {
@@ -490,11 +490,7 @@ public class ZendeskInputPlugin implements InputPlugin
 
     private boolean isValidTimeRange(PluginTask task)
     {
-        if (task.getEndTime().isPresent()) {
-            return ZendeskDateUtils.isoToEpochSecond(task.getEndTime().get()) <= Instant.now().getEpochSecond();
-        }
-
-        return true;
+        return !task.getEndTime().isPresent() || ZendeskDateUtils.isoToEpochSecond(task.getEndTime().get()) <= Instant.now().getEpochSecond();
     }
 
     private TaskReport buildTaskReportKeepOldStartAndEndTime(PluginTask task)

--- a/src/main/java/org/embulk/input/zendesk/ZendeskInputPlugin.java
+++ b/src/main/java/org/embulk/input/zendesk/ZendeskInputPlugin.java
@@ -206,7 +206,7 @@ public class ZendeskInputPlugin implements InputPlugin
         }
         else {
             if (!isValidTimeRange(task)) {
-                logger.info("It is not a valid time range, end time: '" + task.getEndTime().get() + "'. Skip this run");
+                logger.info("The end time, '" + task.getEndTime().get() + "', is greater than the current time. No records will be imported. Data will be imported in next runs");
                 return buildTaskReportKeepOldStartAndEndTime(task);
             }
         }
@@ -490,7 +490,7 @@ public class ZendeskInputPlugin implements InputPlugin
 
     private boolean isValidTimeRange(PluginTask task)
     {
-        if (task.getEndTime().isPresent()) {
+        if (task.getEndTime().isPresent() && task.getIncremental()) {
             return ZendeskDateUtils.isoToEpochSecond(task.getEndTime().get()) <= Instant.now().getEpochSecond();
         }
 

--- a/src/main/java/org/embulk/input/zendesk/ZendeskInputPlugin.java
+++ b/src/main/java/org/embulk/input/zendesk/ZendeskInputPlugin.java
@@ -205,15 +205,14 @@ public class ZendeskInputPlugin implements InputPlugin
             if (Exec.isPreview()) {
                 throw new ConfigException("Invalid End time. End time is greater than current time");
             }
-            else {
-                logger.warn("The end time, '" + task.getEndTime().get() + "', is greater than the current time. No records will be imported");
 
-                // we just need to store config_diff when incremental_mode is enable
-                if (task.getIncremental()) {
-                    return buildTaskReportKeepOldStartAndEndTime(task);
-                }
-                return Exec.newTaskReport();
+            logger.warn("The end time, '" + task.getEndTime().get() + "', is greater than the current time. No records will be imported");
+
+            // we just need to store config_diff when incremental_mode is enable
+            if (task.getIncremental()) {
+                return buildTaskReportKeepOldStartAndEndTime(task);
             }
+            return Exec.newTaskReport();
         }
 
         try (final PageBuilder pageBuilder = getPageBuilder(schema, output)) {

--- a/src/main/java/org/embulk/input/zendesk/ZendeskInputPlugin.java
+++ b/src/main/java/org/embulk/input/zendesk/ZendeskInputPlugin.java
@@ -206,8 +206,8 @@ public class ZendeskInputPlugin implements InputPlugin
         }
         else {
             if (!isValidTimeRange(task)) {
-                logger.info("It is not a valid time range, end time: '"+ task.getEndTime().get() +"'. Skip this run");
-                return buildTaskReportWithTheSameStartTimeAndEndTime(task);
+                logger.info("It is not a valid time range, end time: '" + task.getEndTime().get() + "'. Skip this run");
+                return buildTaskReportKeepOldStartAndEndTime(task);
             }
         }
 
@@ -497,7 +497,7 @@ public class ZendeskInputPlugin implements InputPlugin
         return true;
     }
 
-    private TaskReport buildTaskReportWithTheSameStartTimeAndEndTime(PluginTask task)
+    private TaskReport buildTaskReportKeepOldStartAndEndTime(PluginTask task)
     {
         final TaskReport taskReport = Exec.newTaskReport();
 

--- a/src/main/java/org/embulk/input/zendesk/services/ZendeskNormalServices.java
+++ b/src/main/java/org/embulk/input/zendesk/services/ZendeskNormalServices.java
@@ -84,8 +84,8 @@ public abstract class ZendeskNormalServices implements ZendeskService
 
         if (task.getStartTime().isPresent()) {
             startTime = ZendeskDateUtils.getStartTime(task.getStartTime().get());
+            initStartTime = startTime;
         }
-        initStartTime = startTime;
 
         if (task.getEndTime().isPresent()) {
             endTime = ZendeskDateUtils.isoToEpochSecond(task.getEndTime().get());
@@ -168,7 +168,7 @@ public abstract class ZendeskNormalServices implements ZendeskService
                         ? apiEndTime + 1
                         : apiEndTime;
 
-                if (numberOfRecords < ZendeskConstants.Misc.MAXIMUM_RECORDS_INCREMENTAL || apiEndTime > endTime) {
+                if (numberOfRecords < ZendeskConstants.Misc.MAXIMUM_RECORDS_INCREMENTAL || startTime > endTime) {
                     break;
                 }
             }

--- a/src/main/java/org/embulk/input/zendesk/services/ZendeskNormalServices.java
+++ b/src/main/java/org/embulk/input/zendesk/services/ZendeskNormalServices.java
@@ -11,6 +11,7 @@ import org.embulk.config.TaskReport;
 import org.embulk.input.zendesk.RecordImporter;
 import org.embulk.input.zendesk.ZendeskInputPlugin;
 import org.embulk.input.zendesk.clients.ZendeskRestClient;
+import org.embulk.input.zendesk.models.Target;
 import org.embulk.input.zendesk.models.ZendeskException;
 import org.embulk.input.zendesk.utils.ZendeskConstants;
 import org.embulk.input.zendesk.utils.ZendeskDateUtils;
@@ -77,10 +78,17 @@ public abstract class ZendeskNormalServices implements ZendeskService
 
     private void importDataForIncremental(final ZendeskInputPlugin.PluginTask task, final RecordImporter recordImporter, final TaskReport taskReport)
     {
+        long initStartTime = 0;
         long startTime = 0;
+        long endTime = Long.MAX_VALUE;
 
         if (task.getStartTime().isPresent()) {
             startTime = ZendeskDateUtils.getStartTime(task.getStartTime().get());
+        }
+        initStartTime = startTime;
+
+        if (task.getEndTime().isPresent()) {
+            endTime = ZendeskDateUtils.isoToEpochSecond(task.getEndTime().get());
         }
 
         // For incremental target, we will run in one task but split in multiple threads inside for data deduplication.
@@ -92,12 +100,14 @@ public abstract class ZendeskNormalServices implements ZendeskService
                     10, 100, 60, TimeUnit.SECONDS, new LinkedBlockingQueue<>()
             );
 
+            long resultEndTime = 0;
             while (true) {
                 int recordCount = 0;
 
                 // Page argument isn't used in incremental API so we just set it to 0
                 final JsonNode result = getDataFromPath("", 0, false, startTime);
                 final Iterator<JsonNode> iterator = ZendeskUtils.getListRecords(result, task.getTarget().getJsonName());
+                resultEndTime = result.get(ZendeskConstants.Field.END_TIME).asLong();
 
                 int numberOfRecords = 0;
                 if (result.has(ZendeskConstants.Field.COUNT)) {
@@ -109,6 +119,29 @@ public abstract class ZendeskNormalServices implements ZendeskService
 
                     if (isUpdatedBySystem(recordJsonNode, startTime)) {
                         continue;
+                    }
+
+                    // Contain some records  that later than end_time. Checked and don't add.
+                    // Because the api already sorted by updated_at or timestamp for ticket_events, we just need to break no need to check further.
+                    if (resultEndTime > endTime) {
+                        long checkedTime = 0;
+                        if (recordJsonNode.has(ZendeskConstants.Field.UPDATED_AT) && !recordJsonNode.get(ZendeskConstants.Field.UPDATED_AT).isNull()) {
+                            checkedTime = ZendeskDateUtils.isoToEpochSecond(recordJsonNode.get(ZendeskConstants.Field.UPDATED_AT).textValue());
+                        }
+
+                        // ticket events is updated by system not user's action so it only has timestamp field
+                        if (task.getTarget().equals(Target.TICKET_EVENTS) && recordJsonNode.has("timestamp") && !recordJsonNode.get("timestamp").isNull()) {
+                            checkedTime = recordJsonNode.get("timestamp").asLong();
+                        }
+
+                        // scores (or response) is only store rated_at time
+                        if (task.getTarget().equals(Target.SCORES) && recordJsonNode.has("rated_at") && !recordJsonNode.get("rated_at").isNull()) {
+                            checkedTime = ZendeskDateUtils.isoToEpochSecond(recordJsonNode.get("rated_at").textValue());
+                        }
+
+                        if (checkedTime > endTime) {
+                            break;
+                        }
                     }
 
                     if (task.getDedup()) {
@@ -132,6 +165,7 @@ public abstract class ZendeskNormalServices implements ZendeskService
                 // https://developer.zendesk.com/rest_api/docs/support/incremental_export#pagination
                 // When there are more than 1000 records share the same time stamp, the count > 1000
                 long apiEndTime = result.get(ZendeskConstants.Field.END_TIME).asLong();
+
                 startTime = startTime == apiEndTime
                         ? apiEndTime + 1
                         : apiEndTime;
@@ -142,7 +176,7 @@ public abstract class ZendeskNormalServices implements ZendeskService
             }
 
             if (!Exec.isPreview()) {
-                storeStartTimeForConfigDiff(taskReport, startTime);
+                storeStartTimeForConfigDiff(taskReport, initStartTime, startTime);
             }
         }
         finally {
@@ -159,19 +193,42 @@ public abstract class ZendeskNormalServices implements ZendeskService
         }
     }
 
-    private void storeStartTimeForConfigDiff(final TaskReport taskReport, final long resultEndTime)
+    private void storeStartTimeForConfigDiff(final TaskReport taskReport, final long initStartTime, final long resultEndTime)
     {
         if (task.getIncremental()) {
-            // resultEndTime = 0 mean no records, we should store now time for next run
+            long nextStartTime;
+            long now = Instant.now().getEpochSecond();
+            // no record to add
             if (resultEndTime == 0) {
-                taskReport.set(ZendeskConstants.Field.START_TIME, Instant.now().getEpochSecond());
+                nextStartTime = now;
+                if (task.getEndTime().isPresent()) {
+                    long endTime = ZendeskDateUtils.isoToEpochSecond(task.getEndTime().get());
+                    taskReport.set(ZendeskConstants.Field.END_TIME, nextStartTime + endTime - initStartTime);
+                }
             }
             else {
-                // NOTE: start_time compared as "=>", not ">".
-                // If we will use end_time for next start_time, we got the same records that are fetched
-                // end_time + 1 is workaround for that
-                taskReport.set(ZendeskConstants.Field.START_TIME, resultEndTime + 1);
+                if (task.getEndTime().isPresent()) {
+                    long endTime = ZendeskDateUtils.isoToEpochSecond(task.getEndTime().get());
+                    if (endTime <= now) {
+                        nextStartTime = endTime + 1;
+                    }
+                    else {
+                        // in the future so just ignore end_time here
+                        nextStartTime = resultEndTime + 1;
+                    }
+
+                    // Should always increase end_time by a decent amount of time to prevent missing records
+                    taskReport.set(ZendeskConstants.Field.END_TIME, nextStartTime + endTime - initStartTime);
+                }
+                else {
+                    // NOTE: start_time compared as "=>", not ">".
+                    // If we will use end_time for next start_time, we got the same records that are fetched
+                    // end_time + 1 is workaround for that
+                    nextStartTime = resultEndTime + 1;
+                }
             }
+
+            taskReport.set(ZendeskConstants.Field.START_TIME, nextStartTime);
         }
     }
 

--- a/src/main/java/org/embulk/input/zendesk/utils/ZendeskConstants.java
+++ b/src/main/java/org/embulk/input/zendesk/utils/ZendeskConstants.java
@@ -43,11 +43,11 @@ public class ZendeskConstants
     public static class Misc
     {
         public static final String RUBY_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S%z";
-        public static final String RUBY_TIMESTAMP_FORMAT_INPUT = "yyyy-MM-dd HH:mm:ss Z";
-        public static final String JAVA_TIMESTAMP_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
-        public static final String ISO_TIMESTAMP_FORMAT = "yyyy-MM-dd'T'HH:mm:ssXXX";
-        public static final String ISO_INSTANT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
-        public static final String RUBY_TIMESTAMP_FORMAT_INPUT_NO_SPACE = "yyyy-MM-dd HH:mm:ssZ";
+        public static final String RUBY_TIMESTAMP_FORMAT_INPUT = "uuuu-MM-dd HH:mm:ss Z";
+        public static final String JAVA_TIMESTAMP_FORMAT = "uuuu-MM-dd'T'HH:mm:ss.SSS'Z'";
+        public static final String ISO_TIMESTAMP_FORMAT = "uuuu-MM-dd'T'HH:mm:ssXXX";
+        public static final String ISO_INSTANT = "uuuu-MM-dd'T'HH:mm:ss'Z'";
+        public static final String RUBY_TIMESTAMP_FORMAT_INPUT_NO_SPACE = "uuuu-MM-dd HH:mm:ssZ";
         public static final String TOO_RECENT_START_TIME = "Too recent start_time.";
         public static final int RECORDS_SIZE_PER_PAGE = 100;
         public static final int MAXIMUM_RECORDS_INCREMENTAL = 1000;

--- a/src/main/java/org/embulk/input/zendesk/utils/ZendeskDateUtils.java
+++ b/src/main/java/org/embulk/input/zendesk/utils/ZendeskDateUtils.java
@@ -46,8 +46,7 @@ public class ZendeskDateUtils
 
     public static String convertToDateTimeFormat(String datetime, String dateTimeFormat)
     {
-        return OffsetDateTime.ofInstant(Instant.ofEpochSecond(ZendeskDateUtils.isoToEpochSecond(datetime)), ZoneOffset.UTC)
-                .format(DateTimeFormatter.ofPattern(dateTimeFormat));
+        return Instant.ofEpochSecond(ZendeskDateUtils.isoToEpochSecond(datetime)).atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern(dateTimeFormat));
     }
 
     // start_time should be start from 0

--- a/src/main/java/org/embulk/input/zendesk/utils/ZendeskDateUtils.java
+++ b/src/main/java/org/embulk/input/zendesk/utils/ZendeskDateUtils.java
@@ -9,6 +9,7 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 
+import java.time.format.ResolverStyle;
 import java.util.Optional;
 
 public class ZendeskDateUtils
@@ -21,9 +22,14 @@ public class ZendeskDateUtils
     {
         final Optional<String> pattern = supportedTimeFormat(time);
         if (pattern.isPresent()) {
-            final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern.get()).withZone(ZoneOffset.UTC);
-            final OffsetDateTime offsetDateTime = LocalDateTime.parse(time, formatter).atOffset(ZoneOffset.UTC);
-            return offsetDateTime.toInstant().getEpochSecond();
+            final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern.get()).withZone(ZoneOffset.UTC).withResolverStyle(ResolverStyle.STRICT);
+            try {
+                final OffsetDateTime offsetDateTime = LocalDateTime.parse(time, formatter).atOffset(ZoneOffset.UTC);
+                return offsetDateTime.toInstant().getEpochSecond();
+            }
+            catch (DateTimeParseException e) {
+                throw new DataException(e.getMessage());
+            }
         }
 
         throw new DataException("Fail to parse value '" + time + "' follow formats " + ZendeskConstants.Misc.SUPPORT_DATE_TIME_FORMAT.toString());

--- a/src/test/java/org/embulk/input/zendesk/TestZendeskInputPlugin.java
+++ b/src/test/java/org/embulk/input/zendesk/TestZendeskInputPlugin.java
@@ -310,7 +310,7 @@ public class TestZendeskInputPlugin
     }
 
     @Test
-    public void runShouldReturnSameStartTimeAndEndTime()
+    public void runShouldKeepOldStartTimeAndEndTimeInConfigDiff()
     {
         ConfigSource configSource = ZendeskTestHelper.getConfigSource("base_validator.yml");
         ZendeskTestHelper.setPreviewMode(embulk, false);

--- a/src/test/java/org/embulk/input/zendesk/TestZendeskInputPlugin.java
+++ b/src/test/java/org/embulk/input/zendesk/TestZendeskInputPlugin.java
@@ -292,7 +292,7 @@ public class TestZendeskInputPlugin
     public void isValidTimeRangeShouldThrowException()
     {
         ZendeskTestHelper.setPreviewMode(embulk, true);
-        String expectedMessage = "End_Date must not be after now.";
+        String expectedMessage = "Invalid End time. End time is greater than current time";
         ConfigSource configSource = ZendeskTestHelper.getConfigSource("base_validator.yml");
         when(zendeskSupportAPIService.isSupportIncremental()).thenReturn(true);
         configSource.set("start_time", OffsetDateTime.ofInstant(Instant.ofEpochSecond(Instant.now().getEpochSecond()), ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT));

--- a/src/test/java/org/embulk/input/zendesk/TestZendeskInputPlugin.java
+++ b/src/test/java/org/embulk/input/zendesk/TestZendeskInputPlugin.java
@@ -291,6 +291,7 @@ public class TestZendeskInputPlugin
     @Test
     public void isValidTimeRangeShouldThrowException()
     {
+        ZendeskTestHelper.setPreviewMode(embulk, true);
         String expectedMessage = "End_Date must not be after now.";
         ConfigSource configSource = ZendeskTestHelper.getConfigSource("base_validator.yml");
         when(zendeskSupportAPIService.isSupportIncremental()).thenReturn(true);
@@ -299,7 +300,6 @@ public class TestZendeskInputPlugin
 
         assertValidation(configSource, expectedMessage);
 
-        ZendeskTestHelper.setPreviewMode(embulk, true);
         try {
             zendeskInputPlugin.transaction(configSource, new Control());
             fail("Should not reach here");

--- a/src/test/java/org/embulk/input/zendesk/TestZendeskInputPlugin.java
+++ b/src/test/java/org/embulk/input/zendesk/TestZendeskInputPlugin.java
@@ -266,8 +266,14 @@ public class TestZendeskInputPlugin
         ConfigSource configSource = ZendeskTestHelper.getConfigSource("base_validator.yml");
         configSource.set("target", Target.USER_EVENTS.name().toLowerCase());
         assertValidation(configSource, "Profile Source is required for User Event Target");
+    }
 
-        configSource.set("profile_source", "");
+    @Test
+    public void validateTimeShouldThrowException()
+    {
+        ConfigSource configSource = ZendeskTestHelper.getConfigSource("base_validator.yml");
+        when(zendeskSupportAPIService.isSupportIncremental()).thenReturn(true);
+        configSource.set("target", Target.TICKETS.name().toLowerCase());
         configSource.set("start_time", OffsetDateTime.ofInstant(Instant.ofEpochSecond(Instant.now().getEpochSecond()), ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT));
         configSource.set("end_time", "2019-12-2 22-12-22");
         assertValidation(configSource, "End Time should follow these format " + ZendeskConstants.Misc.SUPPORT_DATE_TIME_FORMAT.toString());

--- a/src/test/java/org/embulk/input/zendesk/utils/TestZendeskDateUtils.java
+++ b/src/test/java/org/embulk/input/zendesk/utils/TestZendeskDateUtils.java
@@ -79,7 +79,7 @@ public class TestZendeskDateUtils
         assertEquals(0, actualValue);
 
         actualValue = ZendeskDateUtils.getStartTime("2019-02-30 06:50:45 +0000");
-        assertEquals(ZendeskDateUtils.getStartTime("2019-02-28 06:50:45 +0000"), actualValue);
+        assertEquals(0, actualValue);
 
         actualValue = ZendeskDateUtils.getStartTime("2019-02-20 06:50:45 +0000");
         assertEquals(expectedValue, actualValue);

--- a/src/test/java/org/embulk/input/zendesk/utils/ZendeskTestHelper.java
+++ b/src/test/java/org/embulk/input/zendesk/utils/ZendeskTestHelper.java
@@ -76,4 +76,17 @@ public final class ZendeskTestHelper
             Assert.fail(e.getMessage());
         }
     }
+
+    public static void setPreviewMode(final ZendeskPluginTestRuntime runtime, final boolean isPreview)
+    {
+        // A small hack to make the plugin executed in preview mode so
+        try {
+            final Field previewField = ExecSession.class.getDeclaredField("preview");
+            previewField.setAccessible(true);
+            previewField.set(runtime.getExec(), isPreview);
+        }
+        catch (NoSuchFieldException | IllegalAccessException e) {
+            Assert.fail(e.getMessage());
+        }
+    }
 }

--- a/src/test/resources/config/nps.yml
+++ b/src/test/resources/config/nps.yml
@@ -13,6 +13,8 @@ incremental: true
 retry_initial_wait_sec: 1
 max_retry_wait_sec: 30
 retry_limit: 2
+start_time: '2019-01-20T07:14:50Z'
+end_time: '2019-01-20T07:14:53Z'
 columns:
   - {name: id, type: long}
   - {name: survey_id, type: string}


### PR DESCRIPTION
Add support end_time for incremental.
Because the incremental fetch data from `start_time` to now and it is too long. So we introduce a new field `end_time` here to make it shorter.
We will fetch from `start_time` -> `end_time`
`end_time` will be updated and stored for the next run

https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html
Java 8 DateTimeFormatter uses yyyy to mean YEAR_OF_ERA, and uuuu to mean YEAR