### PR TITLE
Remove use of ConfigSource#getObjectNodes from embulk core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 script:
   - ./gradlew checkstyle test jacocoTestReport

--- a/src/main/java/org/embulk/input/zendesk/ZendeskInputPlugin.java
+++ b/src/main/java/org/embulk/input/zendesk/ZendeskInputPlugin.java
@@ -286,7 +286,7 @@ public class ZendeskInputPlugin implements InputPlugin
         final Buffer bufferSample = Buffer.copyOf(sample.toString().getBytes(StandardCharsets.UTF_8));
         final JsonNode columns = Exec.getInjector().getInstance(GuessExecutor.class)
                 .guessParserConfig(bufferSample, Exec.newConfigSource(), createGuessConfig())
-                .getObjectNode().get("columns");
+                .get(JsonNode.class,  "columns");
 
         final Iterator<JsonNode> ite = columns.elements();
 


### PR DESCRIPTION
Since embulk core will remove method ConfigSource#getObjectNodes we should replace it
Also fix the travis build