### PR TITLE
Improve chat validation dueto Chat endpoint update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.4.5 - 2024-10-29
+* [enhancement] Remove checking for Chat API due to domain update [#87](https://github.com/treasure-data/embulk-input-zendesk/pull/87)
+
 ## 0.4.4 - 2023-07-21
 * [enhancement] Support cursor based incremental [#84](https://github.com/treasure-data/embulk-input-zendesk/pull/84)
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ repositories {
 def embulkVersion = '0.10.31'
 
 group = "com.treasuredata.embulk.plugins"
-version = "0.4.4-SNAPSHOT"
+version = "0.4.5-SNAPSHOT"
 description = "Loads records From Zendesk"
 
 sourceCompatibility = 1.8

--- a/src/main/java/org/embulk/input/zendesk/clients/ZendeskRestClient.java
+++ b/src/main/java/org/embulk/input/zendesk/clients/ZendeskRestClient.java
@@ -173,11 +173,7 @@ public class ZendeskRestClient
                 // In case we can't parse the message, error should not be show here
             }
 
-            if (target.equals(Target.CHAT) && !Pattern.compile(ZendeskConstants.Regex.CHAT_LOGIN_URL).matcher(loginURL).matches()) {
-                throw new ConfigException("Invalid login url. Check that you are using https://www.zopim.com to import chat data.");
-            }
-
-            if (!target.equals(Target.CHAT) && !Pattern.compile(ZendeskConstants.Regex.LOGIN_URL).matcher(loginURL).matches()) {
+            if (!Pattern.compile(ZendeskConstants.Regex.LOGIN_URL).matcher(loginURL).matches()) {
                 throw new ConfigException("Invalid login url. Check that you are using the correct Zendesk url (https://example.zendesk.com/) to import data.");
             }
 
@@ -214,12 +210,7 @@ public class ZendeskRestClient
         // Won't retry for 4xx range errors except above. Almost they should be ConfigError e.g. 403 Forbidden
         if (status / 100 == 4) {
             if (status == HttpStatus.SC_UNAUTHORIZED) {
-                if (target.equals(Target.CHAT)) {
-                    throw new ConfigException("Invalid credentials. Check that you are using your Zopim credentials to import Chat data.");
-                }
-                else {
-                    throw new ConfigException("Invalid credentials. Check that you are using your Zendesk credentials to import non-Chat data.");
-                }
+                throw new ConfigException("Invalid credentials. Check that you are using your Zendesk credentials.");
             }
 
             if (status == HttpStatus.SC_FORBIDDEN) {

--- a/src/main/java/org/embulk/input/zendesk/utils/ZendeskConstants.java
+++ b/src/main/java/org/embulk/input/zendesk/utils/ZendeskConstants.java
@@ -68,7 +68,6 @@ public class ZendeskConstants
     {
         public static final String ID = "_id$";
         public static final String LOGIN_URL = "^https?://+[a-z0-9_\\\\-]+(.zendesk.com/?)$";
-        public static final String CHAT_LOGIN_URL = "^https://www.zopim.com/?$";
     }
 
     public static class HttpStatus

--- a/src/test/java/org/embulk/input/zendesk/clients/TestZendeskRestClient.java
+++ b/src/test/java/org/embulk/input/zendesk/clients/TestZendeskRestClient.java
@@ -151,62 +151,16 @@ public class TestZendeskRestClient
     }
 
     @Test
-    public void doThrowWrongHostExceptionForChatWhen404()
-    {
-        setup("doGet404");
-        ConfigSource configSource = ZendeskTestHelper.getConfigSource("incremental.yml");
-        configSource.set("auth_method", "oauth");
-        configSource.set("access_token", "token");
-        configSource.set("target", "chat");
-        configSource.set("login_url", "https://abc.zendesk.com");
-        PluginTask pluginTask = CONFIG_MAPPER.map(configSource, PluginTask.class);
-
-        String expectedMessage = "Invalid login url. Check that you are using https://www.zopim.com to import chat data.";
-        int expectedRetryTime = 1;
-        try {
-            zendeskRestClient.doGet("any", pluginTask, false);
-            fail("Should not reach here");
-        }
-        catch (final Exception e) {
-            assertEquals(expectedMessage, e.getMessage());
-        }
-        verify(zendeskRestClient, times(expectedRetryTime)).createHttpClient();
-    }
-
-    @Test
     public void doThrowWrongHostExceptionForNonChatWhen404()
     {
         setup("doGet404");
         ConfigSource configSource = ZendeskTestHelper.getConfigSource("incremental.yml");
         configSource.set("auth_method", "oauth");
         configSource.set("access_token", "token");
-        configSource.set("login_url", "https://www.zopim.com/");
+        configSource.set("login_url", "https://www.chat.zendesk.com/");
         PluginTask pluginTask = CONFIG_MAPPER.map(configSource, PluginTask.class);
 
         String expectedMessage = "Invalid login url. Check that you are using the correct Zendesk url (https://example.zendesk.com/) to import data.";
-        int expectedRetryTime = 1;
-        try {
-            zendeskRestClient.doGet("any", pluginTask, false);
-            fail("Should not reach here");
-        }
-        catch (final Exception e) {
-            assertEquals(expectedMessage, e.getMessage());
-        }
-        verify(zendeskRestClient, times(expectedRetryTime)).createHttpClient();
-    }
-
-    @Test
-    public void doThrowCredentialWrongExceptionForChatWhen401()
-    {
-        setup("credentialFail401");
-        ConfigSource configSource = ZendeskTestHelper.getConfigSource("incremental.yml");
-        configSource.set("auth_method", "oauth");
-        configSource.set("access_token", "token");
-        configSource.set("target", "chat");
-        configSource.set("login_url", "https://abc.zendesk.com");
-        PluginTask pluginTask = CONFIG_MAPPER.map(configSource, PluginTask.class);
-
-        String expectedMessage = "Invalid credentials. Check that you are using your Zopim credentials to import Chat data.";
         int expectedRetryTime = 1;
         try {
             zendeskRestClient.doGet("any", pluginTask, false);
@@ -225,10 +179,10 @@ public class TestZendeskRestClient
         ConfigSource configSource = ZendeskTestHelper.getConfigSource("incremental.yml");
         configSource.set("auth_method", "oauth");
         configSource.set("access_token", "token");
-        configSource.set("login_url", "https://www.zopim.com/");
+        configSource.set("login_url", "https://www.chat.zendesk.com/");
         PluginTask pluginTask = CONFIG_MAPPER.map(configSource, PluginTask.class);
 
-        String expectedMessage = "Invalid credentials. Check that you are using your Zendesk credentials to import non-Chat data.";
+        String expectedMessage = "Invalid credentials. Check that you are using your Zendesk credentials.";
         int expectedRetryTime = 1;
         try {
             zendeskRestClient.doGet("any", pluginTask, false);

--- a/src/test/java/org/embulk/input/zendesk/services/TestZendeskChatService.java
+++ b/src/test/java/org/embulk/input/zendesk/services/TestZendeskChatService.java
@@ -58,9 +58,9 @@ public class TestZendeskChatService
         JsonNode dataSearchJson = ZendeskTestHelper.getJsonFromFile("data/chat_search.json");
         JsonNode dataJson = ZendeskTestHelper.getJsonFromFile("data/chat.json");
 
-        when(zendeskRestClient.doGet(eq("https://www.zopim.com/api/v2/chats/search?q=timestamp%3A%5B2018-09-15T05%3A00%3A00Z+TO+2019-09-29T05%3A00%3A00Z%5D&page=1"), any(), anyBoolean())).thenReturn(dataSearchJson.toString());
+        when(zendeskRestClient.doGet(eq("https://www.chat.zendesk.com/api/v2/chats/search?q=timestamp%3A%5B2018-09-15T05%3A00%3A00Z+TO+2019-09-29T05%3A00%3A00Z%5D&page=1"), any(), anyBoolean())).thenReturn(dataSearchJson.toString());
 
-        when(zendeskRestClient.doGet(eq("https://www.zopim.com/api/v2/chats?ids=id_1%2Cid_2"), any(), anyBoolean())).thenReturn(dataJson.toString());
+        when(zendeskRestClient.doGet(eq("https://www.chat.zendesk.com/api/v2/chats?ids=id_1%2Cid_2"), any(), anyBoolean())).thenReturn(dataJson.toString());
 
         zendeskChatService.fetchData("2018-09-15T05:00:00Z", "2019-09-29T05:00:00Z", 1, recordImporter);
 

--- a/src/test/resources/config/chat.yml
+++ b/src/test/resources/config/chat.yml
@@ -1,5 +1,5 @@
 type: zendesk
-login_url: https://www.zopim.com
+login_url: https://www.chat.zendesk.com
 auth_method: basic
 username: username
 password: password

--- a/src/test/resources/data/chat_search.json
+++ b/src/test/resources/data/chat_search.json
@@ -4,14 +4,14 @@
       "id": "id_1",
       "timestamp": "2019-10-12T21:43:23Z",
       "preview": "abc",
-      "url": "https://www.zopim.com/api/v2/chats/id_1",
+      "url": "https://www.chat.zendesk.com/api/v2/chats/id_1",
       "type": "offline_msg"
     },
     {
       "id": "id_2",
       "timestamp": "2019-10-12T20:02:54Z",
       "preview": "abc",
-      "url": "https://www.zopim.com/api/v2/chats/id_2",
+      "url": "https://www.chat.zendesk.com/api/v2/chats/id_2",
       "type": "offline_msg"
     }
   ],


### PR DESCRIPTION
Zedesk has been updated the Chat domain from https://www.zopim.com/ to https://(subdomain).zendesk.com

https://support.zendesk.com/hc/en-us/articles/7827476398362-Deprecating-the-Zopim-Chat-REST-API-domain

We should remove the checking for the old one to improve the current connector