### PR TITLE
Update Chat API endpoint follow new pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 0.4.5 - 2024-10-29
+## 0.4.6 - 2024-10-24
+* [enhancement] Update the API endpoint pattern for Chat endpoint [#88](https://github.com/treasure-data/embulk-input-zendesk/pull/88)
+
+## 0.4.5 - 2024-10-24
 * [enhancement] Remove checking for Chat API due to domain update [#87](https://github.com/treasure-data/embulk-input-zendesk/pull/87)
 
 ## 0.4.4 - 2023-07-21

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ repositories {
 def embulkVersion = '0.10.31'
 
 group = "com.treasuredata.embulk.plugins"
-version = "0.4.5-SNAPSHOT"
+version = "0.4.6-SNAPSHOT"
 description = "Loads records From Zendesk"
 
 sourceCompatibility = 1.8

--- a/src/main/java/org/embulk/input/zendesk/services/ZendeskChatService.java
+++ b/src/main/java/org/embulk/input/zendesk/services/ZendeskChatService.java
@@ -276,6 +276,9 @@ public class ZendeskChatService implements ZendeskService
             : OffsetDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
     }
 
+    // Zopim domain is the domain for old Chat API
+    // But it will be removed soon and replaced by new Chat API follow new pattern {subdomain}.zendesk.com/api/v2/chat
+    // The expected released day is before October 29, 2024. So we need to handle this case
     private String resolveEndpointPatternByDomain(String endpoint)
     {
         if (isZopimDomain()) {

--- a/src/main/java/org/embulk/input/zendesk/utils/ZendeskConstants.java
+++ b/src/main/java/org/embulk/input/zendesk/utils/ZendeskConstants.java
@@ -40,7 +40,7 @@ public class ZendeskConstants
         public static final String API_OBJECT_RECORD = "api/sunshine/objects/records";
         public static final String API_RELATIONSHIP_RECORD = "api/sunshine/relationships/records";
         public static final String API_USER_EVENT = "api/v2/users/%s/events";
-        public static final String API_CHAT = API + "/chats";
+        public static final String API_CHAT = API + "/chat/chats";
         public static final String API_CHAT_SEARCH = API_CHAT + "/search";
     }
 

--- a/src/main/java/org/embulk/input/zendesk/utils/ZendeskConstants.java
+++ b/src/main/java/org/embulk/input/zendesk/utils/ZendeskConstants.java
@@ -40,8 +40,9 @@ public class ZendeskConstants
         public static final String API_OBJECT_RECORD = "api/sunshine/objects/records";
         public static final String API_RELATIONSHIP_RECORD = "api/sunshine/relationships/records";
         public static final String API_USER_EVENT = "api/v2/users/%s/events";
-        public static final String API_CHAT = API + "/chat/chats";
-        public static final String API_CHAT_SEARCH = API_CHAT + "/search";
+        public static final String NEW_API_CHAT = API + "/chat";
+        public static final String ENDPOINT_CHAT = "/chats";
+        public static final String ENDPOINT_CHAT_SEARCH =  "/chats/search";
     }
 
     public static class Misc
@@ -68,6 +69,8 @@ public class ZendeskConstants
     {
         public static final String ID = "_id$";
         public static final String LOGIN_URL = "^https?://+[a-z0-9_\\\\-]+(.zendesk.com/?)$";
+        public static final String ZOPIM_LOGIN_URL = "^https://www.zopim.com/?$";
+
     }
 
     public static class HttpStatus

--- a/src/test/java/org/embulk/input/zendesk/services/TestZendeskChatService.java
+++ b/src/test/java/org/embulk/input/zendesk/services/TestZendeskChatService.java
@@ -67,6 +67,25 @@ public class TestZendeskChatService
         verify(recordImporter, times(2)).addRecord(any());
     }
 
+    @Test
+    public void testFetchDataWithZopimDomain()
+    {
+        ZendeskInputPlugin.PluginTask task =
+            CONFIG_MAPPER.map(ZendeskTestHelper.getConfigSource("chat.yml").set("login_url", "https://www.zopim.com"), ZendeskInputPlugin.PluginTask.class);
+        setupZendeskChatService(task);
+
+        JsonNode dataSearchJson = ZendeskTestHelper.getJsonFromFile("data/chat_search.json");
+        JsonNode dataJson = ZendeskTestHelper.getJsonFromFile("data/chat.json");
+
+        when(zendeskRestClient.doGet(eq("https://www.zopim.com/api/v2/chats/search?q=timestamp%3A%5B2018-09-15T05%3A00%3A00Z+TO+2019-09-29T05%3A00%3A00Z%5D&page=1"), any(), anyBoolean())).thenReturn(dataSearchJson.toString());
+
+        when(zendeskRestClient.doGet(eq("https://www.zopim.com/api/v2/chats?ids=id_1%2Cid_2"), any(), anyBoolean())).thenReturn(dataJson.toString());
+
+        zendeskChatService.fetchData("2018-09-15T05:00:00Z", "2019-09-29T05:00:00Z", 1, recordImporter);
+
+        verify(recordImporter, times(2)).addRecord(any());
+    }
+
     private void setup()
     {
         ZendeskInputPlugin.PluginTask task =

--- a/src/test/java/org/embulk/input/zendesk/services/TestZendeskChatService.java
+++ b/src/test/java/org/embulk/input/zendesk/services/TestZendeskChatService.java
@@ -58,9 +58,9 @@ public class TestZendeskChatService
         JsonNode dataSearchJson = ZendeskTestHelper.getJsonFromFile("data/chat_search.json");
         JsonNode dataJson = ZendeskTestHelper.getJsonFromFile("data/chat.json");
 
-        when(zendeskRestClient.doGet(eq("https://www.chat.zendesk.com/api/v2/chats/search?q=timestamp%3A%5B2018-09-15T05%3A00%3A00Z+TO+2019-09-29T05%3A00%3A00Z%5D&page=1"), any(), anyBoolean())).thenReturn(dataSearchJson.toString());
+        when(zendeskRestClient.doGet(eq("https://www.chat.zendesk.com/api/v2/chat/chats/search?q=timestamp%3A%5B2018-09-15T05%3A00%3A00Z+TO+2019-09-29T05%3A00%3A00Z%5D&page=1"), any(), anyBoolean())).thenReturn(dataSearchJson.toString());
 
-        when(zendeskRestClient.doGet(eq("https://www.chat.zendesk.com/api/v2/chats?ids=id_1%2Cid_2"), any(), anyBoolean())).thenReturn(dataJson.toString());
+        when(zendeskRestClient.doGet(eq("https://www.chat.zendesk.com/api/v2/chat/chats?ids=id_1%2Cid_2"), any(), anyBoolean())).thenReturn(dataJson.toString());
 
         zendeskChatService.fetchData("2018-09-15T05:00:00Z", "2019-09-29T05:00:00Z", 1, recordImporter);
 


### PR DESCRIPTION
Because the endpoint format of Chat API has been changed from  `zopim.com/api/v2` to `{subdomain}.zendesk.com/api/v2/chat`

The code should be updated follow new pattern